### PR TITLE
Feature/#40 로그인 이후 화면전환 및 버그 수정

### DIFF
--- a/What?fle.xcodeproj/xcuserdata/pane.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/What?fle.xcodeproj/xcuserdata/pane.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -259,7 +259,7 @@
 		<key>What?fle.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>6</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/What?fle/Data/APIs/LoginAPI.swift
+++ b/What?fle/Data/APIs/LoginAPI.swift
@@ -18,7 +18,7 @@ enum LoginAPI: Loginable {
     case signinAgreement([TermsAgreement])
     case snsLogin(LoginRequestModel)
     case updateProfile(UserProfile)
-    
+    case getUserInfo
 
     var requiresLogin: Bool {
         switch self {
@@ -44,6 +44,8 @@ extension LoginAPI: TargetType {
             return basePath + "/account/signin"
         case .updateProfile:
             return basePath + "/account/profile"
+        case .getUserInfo:
+            return basePath + "/account"
         }
     }
 

--- a/What?fle/Data/Services/LoginRepository.swift
+++ b/What?fle/Data/Services/LoginRepository.swift
@@ -72,4 +72,8 @@ final class LoginRepository: LoginRepositoryProtocol {
     func updateUserProfile(userProfile: UserProfile) -> Single<UserInfo> {
         return networkService.request(LoginAPI.updateProfile(userProfile))
     }
+    
+    func getUserInfo() -> Single<UserInfo> {
+        return networkService.request(LoginAPI.getUserInfo)
+    }
 }

--- a/What?fle/Domain/Entities/Login/UserInfo.swift
+++ b/What?fle/Domain/Entities/Login/UserInfo.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct UserInfo: Codable {
-    let id: Int?
+    let id: Int
     let thirdPartyAuthType: String
     let thirdPartyAuthUid: String
     let nickname: String?

--- a/What?fle/Domain/Interfaces/LoginRepositoryProtocol.swift
+++ b/What?fle/Domain/Interfaces/LoginRepositoryProtocol.swift
@@ -18,4 +18,5 @@ protocol LoginRepositoryProtocol {
     func existNickname(nickname: String) -> Single<Bool>
     func uploadImage(imageData: Data, fileName: String) -> Single<String>
     func updateUserProfile(userProfile: UserProfile) -> Single<UserInfo>
+    func getUserInfo() -> Single<UserInfo>
 }

--- a/What?fle/Domain/UseCase/LoginUseCase.swift
+++ b/What?fle/Domain/UseCase/LoginUseCase.swift
@@ -16,6 +16,7 @@ protocol LoginUseCaseProtocol {
     func loginInWithIDToken(provider: OpenIDConnectCredentials.Provider, idToken: String) -> Single<(Bool, Bool)>
     func sendTermsAgreement(agreements: [TermsAgreement]) -> Single<UserInfo>
     func updateUserProfile(nickname: String, imageData: Data?) -> Single<Void>
+    func getUserInfo() -> Single<UserInfo>
 }
 
 final class LoginUseCase: LoginUseCaseProtocol {
@@ -80,5 +81,9 @@ final class LoginUseCase: LoginUseCaseProtocol {
                 self.loginRepository.sessionManager.saveUserInfo(userInfo)
             })
             .mapToVoid()
+    }
+    
+    func getUserInfo() -> Single<UserInfo> {
+        return self.loginRepository.getUserInfo()
     }
 }

--- a/What?fle/Extension/String+.swift
+++ b/What?fle/Extension/String+.swift
@@ -70,4 +70,16 @@ extension String {
     func isValidRegistTag() -> Bool {
         return NSPredicate(format: "SELF MATCHES %@", "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]*$").evaluate(with: self)
     }
+
+    func toFormattedDateString(fromFormat: String = "yy.MM.dd", toFormat: String = "yyyy-MM-dd") -> String? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = fromFormat
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        guard let date = dateFormatter.date(from: self) else {
+            return nil
+        }
+        dateFormatter.dateFormat = toFormat
+        return dateFormatter.string(from: date)
+    }
 }

--- a/What?fle/View/Module/Add/AddBuilder.swift
+++ b/What?fle/View/Module/Add/AddBuilder.swift
@@ -13,7 +13,6 @@ protocol AddDependency: Dependency {
     var loginUseCase: LoginUseCaseProtocol { get }
     var locationUseCase: LocationUseCaseProtocol { get }
     var collectionUseCase: CollectionUseCaseProtocol { get }
-    var userInfo: UserInfo? { get }
 }
 
 final class AddComponent: Component<AddDependency> {
@@ -24,9 +23,9 @@ final class AddComponent: Component<AddDependency> {
 
 extension AddComponent: RegistLocationDependency, RegistCollectionDependency {
     var userInfo: UserInfo? {
-        return dependency.userInfo
+        return networkService.sessionManager.loadUserInfo()
     }
-    
+
     var locationUseCase: LocationUseCaseProtocol {
         return dependency.locationUseCase
     }

--- a/What?fle/View/Module/Add/AddInteractor.swift
+++ b/What?fle/View/Module/Add/AddInteractor.swift
@@ -18,7 +18,8 @@ protocol AddRouting: ViewableRouting {
     func popToRegistCollection()
     func popToRegistLocation()
     func showLoginRIB()
-    func dismissLoginRIB()
+    func dismissLoginRIB(completion: (() -> Void)?)
+    func proceedToNextScreenAfterLogin()
 }
 
 protocol AddPresentable: Presentable {
@@ -44,6 +45,10 @@ final class AddInteractor: PresentableInteractor<AddPresentable> {
 }
 
 extension AddInteractor: AddInteractable {
+    func proceedToNextScreenAfterLogin() {
+        self.router?.proceedToNextScreenAfterLogin()
+    }
+    
     func popToAddCollection() {
         self.router?.popToAddCollection()
     }
@@ -76,7 +81,7 @@ extension AddInteractor: AddInteractable {
     func dismissAddCollection() {}
 
     func dismissLoginRIB() {
-        self.router?.dismissLoginRIB()
+        self.router?.dismissLoginRIB(completion: nil)
     }
 }
 

--- a/What?fle/View/Module/Add/AddRouter.swift
+++ b/What?fle/View/Module/Add/AddRouter.swift
@@ -167,9 +167,8 @@ extension AddRouter: AddRouting {
                 completion?()
                 self.detachChild(router)
                 self.loginRouter = nil
+                self.postLoginAction = nil
             }
-        } else {
-            completion?()
         }
     }
 }

--- a/What?fle/View/Module/Add/RegistLocation/RegistLocationBuilder.swift
+++ b/What?fle/View/Module/Add/RegistLocation/RegistLocationBuilder.swift
@@ -8,17 +8,13 @@
 import RIBs
 
 protocol RegistLocationDependency: Dependency {
+    var networkService: NetworkServiceDelegate { get }
     var locationUseCase: LocationUseCaseProtocol { get }
-    var userInfo: UserInfo? { get }
 }
 
 final class RegistLocationComponent: Component<RegistLocationDependency> {
     var locationUseCase: LocationUseCaseProtocol {
         return dependency.locationUseCase
-    }
-    
-    var userInfo: UserInfo? {
-        return dependency.userInfo
     }
 }
 
@@ -35,7 +31,7 @@ extension RegistLocationComponent: SelectLocationDependency, CustomAlbumDependen
 // MARK: - Builder
 
 protocol RegistLocationBuildable: Buildable {
-    func build(withListener listener: RegistLocationListener) -> RegistLocationRouting
+    func build(withListener listener: RegistLocationListener, accountID: Int) -> RegistLocationRouting
 }
 
 final class RegistLocationBuilder: Builder<RegistLocationDependency>, RegistLocationBuildable {
@@ -48,13 +44,13 @@ final class RegistLocationBuilder: Builder<RegistLocationDependency>, RegistLoca
         super.init(dependency: dependency)
     }
 
-    func build(withListener listener: RegistLocationListener) -> RegistLocationRouting {
+    func build(withListener listener: RegistLocationListener, accountID: Int) -> RegistLocationRouting {
         let component = RegistLocationComponent(dependency: dependency)
         let viewController = RegistLocationViewController()
         let interactor = RegistLocationInteractor(
             presenter: viewController,
             locationUseCase: component.locationUseCase,
-            accountID: component.userInfo?.id
+            accountID: accountID
         )
         interactor.listener = listener
         viewController.listener = interactor

--- a/What?fle/View/Module/Add/RegistLocation/RegistLocationInteractor.swift
+++ b/What?fle/View/Module/Add/RegistLocation/RegistLocationInteractor.swift
@@ -38,7 +38,7 @@ final class RegistLocationInteractor: PresentableInteractor<RegistLocationPresen
     private let locationUseCase: LocationUseCaseProtocol
     private let disposeBag = DisposeBag()
 
-    let accountID: Int?
+    let accountID: Int
     var model: KakaoSearchDocumentsModel?
     let imageArray = BehaviorRelay<[UIImage]>(value: [])
     let isSelectLocation = BehaviorRelay<Bool>(value: false)
@@ -50,7 +50,7 @@ final class RegistLocationInteractor: PresentableInteractor<RegistLocationPresen
     init(
         presenter: RegistLocationPresentable,
         locationUseCase: LocationUseCaseProtocol,
-        accountID: Int?
+        accountID: Int
     ) {
         self.locationUseCase = locationUseCase
         self.accountID = accountID

--- a/What?fle/View/Module/Add/RegistLocation/RegistLocationViewController.swift
+++ b/What?fle/View/Module/Add/RegistLocation/RegistLocationViewController.swift
@@ -14,7 +14,7 @@ protocol RegistLocationPresentableListener: AnyObject {
     var imageArray: BehaviorRelay<[UIImage]> { get }
     var isSelectLocation: BehaviorRelay<Bool> { get }
     var model: KakaoSearchDocumentsModel? { get }
-    var accountID: Int? { get }
+    var accountID: Int { get }
     func showSelectLocation()
     func registPlace(_ registration: PlaceRegistration, imageData: [Data])
     func closeRegistLocation()
@@ -336,14 +336,13 @@ final class RegistLocationViewController: ScrollKeyboardVC, RegistLocationViewCo
             .subscribe(onNext: { [weak self] in
                 guard let self,
                       let listener,
-                      let model = listener.model,
-                      let id = listener.accountID else { return }
+                      let model = listener.model else { return }
                 self.memoView.endEditing(true)
                 listener.registPlace(
                     .init(
-                        accountID: id,
+                        accountID: listener.accountID,
                         description: memoView.textView.text,
-                        visitDate: visitTextField.attributedText?.string ?? "",
+                        visitDate: visitTextField.attributedText?.string.toFormattedDateString() ?? "",
                         placeName: model.placeName,
                         address: model.addressName,
                         roadAddress: model.roadAddressName,

--- a/What?fle/View/Module/HelperModuld/ImageView.swift
+++ b/What?fle/View/Module/HelperModuld/ImageView.swift
@@ -39,7 +39,8 @@ final class ImageView: UIImageView {
         }
     }()
 
-    func loadImage(from urlStr: String, placeholder: UIImage? = nil) {
+    func loadImage(from urlStr: String?, placeholder: UIImage? = nil) {
+        guard let urlStr else { return }
         if let placeholder {
             self.image = placeholder
         }

--- a/What?fle/View/Module/Home/DetailCollection/Cells/CoverImageCell.swift
+++ b/What?fle/View/Module/Home/DetailCollection/Cells/CoverImageCell.swift
@@ -36,7 +36,7 @@ final class CoverImageCell: UICollectionViewCell {
         }
     }
 
-    func drawCell(urlStr: String) {
+    func drawCell(urlStr: String?) {
         self.coverImageView.loadImage(from: urlStr)
     }
 }

--- a/What?fle/View/Module/Home/DetailCollection/DetailCollectionInteractor.swift
+++ b/What?fle/View/Module/Home/DetailCollection/DetailCollectionInteractor.swift
@@ -45,7 +45,7 @@ final class DetailCollectionInteractor: PresentableInteractor<DetailCollectionPr
         LoadingIndicatorService.shared.showLoading()
 
         networkService.request(CollectionAPI.getDetailCollection(self.collectionID))
-            .subscribe(onSuccess: { [weak self] result in
+            .subscribe(onSuccess: { [weak self] (result: DetailCollectionModel) in
                 guard let self else { return }
                 self.detailCollectionModel.onNext(result)
             }, onFailure: { error in

--- a/What?fle/View/Module/Home/DetailCollection/DetailCollectionViewController.swift
+++ b/What?fle/View/Module/Home/DetailCollection/DetailCollectionViewController.swift
@@ -132,11 +132,10 @@ extension DetailCollectionViewController: UICollectionViewDataSource, UICollecti
         guard let model else { return UICollectionViewCell() }
         switch indexPath.section {
         case 0:
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CoverImageCell.reuseIdentifier, for: indexPath) as? CoverImageCell,
-                  let urlStr = model.imageURLs?.first else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CoverImageCell.reuseIdentifier, for: indexPath) as? CoverImageCell else {
                 return UICollectionViewCell()
             }
-            cell.drawCell(urlStr: urlStr)
+            cell.drawCell(urlStr: model.imageURLs?.first)
             return cell
         case 1:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DescriptionCell.reuseIdentifier, for: indexPath) as? DescriptionCell else {

--- a/What?fle/View/Module/Home/HomeInteractor.swift
+++ b/What?fle/View/Module/Home/HomeInteractor.swift
@@ -15,7 +15,8 @@ protocol HomeRouting: ViewableRouting {
     func routeToTotalSearchBar()
     func dismissTotalSearchBar()
     func showLoginRIB()
-    func dismissLoginRIB()
+    func dismissLoginRIB(completion: (() -> Void)?)
+    func proceedToNextScreenAfterLogin()
 }
 
 protocol HomePresentable: Presentable {
@@ -44,10 +45,12 @@ final class HomeInteractor: PresentableInteractor<HomePresentable> {
 }
 
 extension HomeInteractor: HomeInteractable {
-    func proceedToNextScreenAfterLogin() {}
+    func proceedToNextScreenAfterLogin() {
+        self.router?.proceedToNextScreenAfterLogin()
+    }
 
     func dismissLoginRIB() {
-        self.router?.dismissLoginRIB()
+        self.router?.dismissLoginRIB(completion: nil)
     }
 
     func popToDetailCollection() {

--- a/What?fle/View/Module/Home/HomeInteractor.swift
+++ b/What?fle/View/Module/Home/HomeInteractor.swift
@@ -44,6 +44,8 @@ final class HomeInteractor: PresentableInteractor<HomePresentable> {
 }
 
 extension HomeInteractor: HomeInteractable {
+    func proceedToNextScreenAfterLogin() {}
+
     func dismissLoginRIB() {
         self.router?.dismissLoginRIB()
     }

--- a/What?fle/View/Module/Home/HomeRouter.swift
+++ b/What?fle/View/Module/Home/HomeRouter.swift
@@ -125,6 +125,7 @@ extension HomeRouter: HomeRouting {
                 completion?()
                 self.detachChild(router)
                 self.loginRouter = nil
+                self.postLoginAction = nil
             }
         }
     }

--- a/What?fle/View/Module/Home/HomeRouter.swift
+++ b/What?fle/View/Module/Home/HomeRouter.swift
@@ -23,6 +23,8 @@ final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable> {
     weak var detailCollectionRouter: DetailCollectionRouting?
     weak var totalSearchBarRouter: TotalSearchBarRouting?
 
+    private var postLoginAction: (() -> Void)?
+
     deinit {
         print("\(self) is being deinit")
     }
@@ -41,8 +43,28 @@ final class HomeRouter: ViewableRouter<HomeInteractable, HomeViewControllable> {
 }
 
 extension HomeRouter: HomeRouting {
+    private func setPostLoginAction(_ action: @escaping () -> Void) {
+        postLoginAction = action
+    }
+
+    private func executePostLoginAction() {
+        postLoginAction?()
+        postLoginAction = nil
+    }
+
+    func proceedToNextScreenAfterLogin() {
+        dismissLoginRIB { [weak self] in
+            guard let self else { return }
+            self.executePostLoginAction()
+        }
+    }
+
     func routeToDetailCollection(id: Int) {
         if !component.networkService.isLogin {
+            self.setPostLoginAction { [weak self] in
+                guard let self else { return }
+                self.routeToDetailCollection(id: id)
+            }
             self.showLoginRIB()
         } else {
             if self.detailCollectionRouter == nil {
@@ -96,11 +118,14 @@ extension HomeRouter: HomeRouting {
         }
     }
 
-    func dismissLoginRIB() {
+    func dismissLoginRIB(completion: (() -> Void)?) {
         if let router = self.loginRouter {
-            self.viewController.uiviewController.dismiss(animated: true)
-            self.detachChild(router)
-            self.loginRouter = nil
+            self.viewController.uiviewController.dismiss(animated: true) { [weak self] in
+                guard let self = self else { return }
+                completion?()
+                self.detachChild(router)
+                self.loginRouter = nil
+            }
         }
     }
 }

--- a/What?fle/View/Module/Home/TotalSearchBar/TotalSearchBarInteractor.swift
+++ b/What?fle/View/Module/Home/TotalSearchBar/TotalSearchBarInteractor.swift
@@ -15,7 +15,8 @@ protocol TotalSearchBarRouting: ViewableRouting {
     var navigationController: UINavigationController? { get }
     func routeToDetailCollection(id: Int)
     func popToDetailCollection()
-    func dismissLoginRIB()
+    func dismissLoginRIB(completion: (() -> Void)?)
+    func proceedToNextScreenAfterLogin()
 }
 
 protocol TotalSearchBarPresentable: Presentable {
@@ -101,10 +102,12 @@ final class TotalSearchBarInteractor: PresentableInteractor<TotalSearchBarPresen
 }
 
 extension TotalSearchBarInteractor: TotalSearchBarInteractable {
-    func proceedToNextScreenAfterLogin() {}
+    func proceedToNextScreenAfterLogin() {
+        self.router?.proceedToNextScreenAfterLogin()
+    }
 
     func dismissLoginRIB() {
-        self.router?.dismissLoginRIB()
+        self.router?.dismissLoginRIB(completion: nil)
     }
 
     func popToDetailCollection() {

--- a/What?fle/View/Module/Home/TotalSearchBar/TotalSearchBarInteractor.swift
+++ b/What?fle/View/Module/Home/TotalSearchBar/TotalSearchBarInteractor.swift
@@ -101,6 +101,8 @@ final class TotalSearchBarInteractor: PresentableInteractor<TotalSearchBarPresen
 }
 
 extension TotalSearchBarInteractor: TotalSearchBarInteractable {
+    func proceedToNextScreenAfterLogin() {}
+
     func dismissLoginRIB() {
         self.router?.dismissLoginRIB()
     }

--- a/What?fle/View/Module/Root/RootBuilder.swift
+++ b/What?fle/View/Module/Root/RootBuilder.swift
@@ -44,9 +44,6 @@ final class RootComponent: Component<RootDependency> {
 }
 
 extension RootComponent: HomeDependency, AddDependency, MapDependency, RegistLocationDependency {
-    var userInfo: UserInfo? {
-        return networkService.sessionManager.loadUserInfo()
-    }
     var homeBuilder: HomeBuildable {
         return HomeBuilder(dependency: self)
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #40 

## 📝작업 내용

> 로그인 이후 화면전환 - 클로져로 액션을 저장하도록 구현
> 유저정보가 갱신 안되는 이슈 수정
> 상세보기 진입시 앱 죽는 이슈 수정 - 이미지 URL이 없는 경우 UICollectionViewCell()로 리턴되는 이슈.
> EmptyCell()을 만들어서 return되도 앱이 죽지 않도록 수정해야함.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
